### PR TITLE
added ansi16/256 conversion

### DIFF
--- a/conversions.js
+++ b/conversions.js
@@ -9,30 +9,40 @@ module.exports = {
   rgb2xyz: rgb2xyz,
   rgb2lab: rgb2lab,
   rgb2lch: rgb2lch,
+  rgb2ansi16: rgb2ansi16,
+  rgb2ansi: rgb2ansi,
 
   hsl2rgb: hsl2rgb,
   hsl2hsv: hsl2hsv,
   hsl2hwb: hsl2hwb,
   hsl2cmyk: hsl2cmyk,
   hsl2keyword: hsl2keyword,
+  hsl2ansi16: hsl2ansi16,
+  hsl2ansi: hsl2ansi,
 
   hsv2rgb: hsv2rgb,
   hsv2hsl: hsv2hsl,
   hsv2hwb: hsv2hwb,
   hsv2cmyk: hsv2cmyk,
   hsv2keyword: hsv2keyword,
+  hsv2ansi16: hsv2ansi16,
+  hsv2ansi: hsv2ansi,
 
   hwb2rgb: hwb2rgb,
   hwb2hsl: hwb2hsl,
   hwb2hsv: hwb2hsv,
   hwb2cmyk: hwb2cmyk,
   hwb2keyword: hwb2keyword,
+  hwb2ansi16: hwb2ansi16,
+  hwb2ansi: hwb2ansi,
 
   cmyk2rgb: cmyk2rgb,
   cmyk2hsl: cmyk2hsl,
   cmyk2hsv: cmyk2hsv,
   cmyk2hwb: cmyk2hwb,
   cmyk2keyword: cmyk2keyword,
+  cmyk2ansi16: cmyk2ansi16,
+  cmyk2ansi: cmyk2ansi,
 
   keyword2rgb: keyword2rgb,
   keyword2hsl: keyword2hsl,
@@ -41,6 +51,8 @@ module.exports = {
   keyword2cmyk: keyword2cmyk,
   keyword2lab: keyword2lab,
   keyword2xyz: keyword2xyz,
+  keyword2ansi16: keyword2ansi16,
+  keyword2ansi: keyword2ansi,
 
   xyz2rgb: xyz2rgb,
   xyz2lab: xyz2lab,
@@ -52,7 +64,21 @@ module.exports = {
 
   lch2lab: lch2lab,
   lch2xyz: lch2xyz,
-  lch2rgb: lch2rgb
+  lch2rgb: lch2rgb,
+
+  ansi162rgb: ansi162rgb,
+  ansi162hsl: ansi162hsl,
+  ansi162hsv: ansi162hsv,
+  ansi162hwb: ansi162hwb,
+  ansi162cmyk: ansi162cmyk,
+  ansi162keyword: ansi162keyword,
+
+  ansi2rgb: ansi2rgb,
+  ansi2hsl: ansi2hsl,
+  ansi2hsv: ansi2hsv,
+  ansi2hwb: ansi2hwb,
+  ansi2cmyk: ansi2cmyk,
+  ansi2keyword: ansi2keyword,
 }
 
 
@@ -539,6 +565,166 @@ function keyword2lab(args) {
 
 function keyword2xyz(args) {
   return rgb2xyz(keyword2rgb(args));
+}
+
+function rgb2ansi16(args) {
+  var r = args[0],
+      g = args[1],
+      b = args[2],
+      value = arguments[1] || rgb2hsv(args)[2]; // hsv2ansi16 optimization
+
+  value = Math.round(value / 50);
+  if (value === 0)
+    return 30;
+
+  var ansi = 30 +
+    ((Math.round(b / 255) << 2) |
+    (Math.round(g / 255) << 1) |
+    Math.round(r / 255));
+
+  if (value === 2)
+    ansi += 60;
+
+  return ansi;
+}
+
+function rgb2ansi(args) {
+  var r = args[0],
+      g = args[1],
+      b = args[2];
+
+  // we use the extended greyscale palette here, with the exception of
+  // black and white. normal palette only has 4 greyscale shades.
+  if (r === g && g === b) {
+    if (r < 8)
+      return 16;
+    if (r > 248)
+      return 231;
+    return Math.round(((r - 8) / 247) * 24) + 232;
+  }
+
+  var ansi = 16 +
+    (36 * Math.round(r / 255 * 5)) +
+    (6 * Math.round(g / 255 * 5)) +
+    Math.round(b / 255 * 5);
+
+  return ansi;
+}
+
+function hsl2ansi16(args) {
+  return rgb2ansi16(hsl2rgb(args));
+}
+
+function hsl2ansi(args) {
+  return rgb2ansi(hsl2rgb(args));
+}
+
+function hsv2ansi16(args) {
+  return rgb2ansi16(hsv2rgb(args), args[2]);
+}
+
+function hsv2ansi(args) {
+  return rgb2ansi(hsv2rgb(args));
+}
+
+function hwb2ansi16(args) {
+  return rgb2ansi16(hwb2rgb(args));
+}
+
+function hwb2ansi(args) {
+  return rgb2ansi(hwb2rgb(args));
+}
+
+function cmyk2ansi16(args) {
+  return rgb2ansi16(cmyk2rgb(args));
+}
+
+function cmyk2ansi(args) {
+  return rgb2ansi(cmyk2rgb(args));
+}
+
+function keyword2ansi16(args) {
+  return rgb2ansi16(keyword2rgb(args));
+}
+
+function keyword2ansi(args) {
+  return rgb2ansi(keyword2rgb(args));
+}
+
+function ansi162rgb(args) {
+  var color = args % 10;
+
+  // handle greyscale
+  if (color === 0 || color === 7) {
+    if (args > 50)
+      color += 3.5;
+    color = color / 10.5 * 255;
+    return [color, color, color];
+  }
+
+  var mult = (~~(args > 50) + 1) * 0.5,
+      r = ((color & 1) * mult) * 255,
+      g = (((color >> 1) & 1) * mult) * 255,
+      b = (((color >> 2) & 1) * mult) * 255;
+
+  return [r, g, b];
+}
+
+function ansi162hsl(args) {
+  return rgb2hsl(ansi162rgb(args));
+}
+
+function ansi162hsv(args) {
+  return rgb2hsv(ansi162rgb(args));
+}
+
+function ansi162hwb(args) {
+  return rgb2hwb(ansi162rgb(args));
+}
+
+function ansi162cmyk(args) {
+  return rgb2cmyk(ansi162rgb(args));
+}
+
+function ansi162keyword(args) {
+  return rgb2keyword(ansi162rgb(args));
+}
+
+function ansi2rgb(args) {
+  // handle greyscale
+  if (args >= 232) {
+    var c = (args - 232) * 10 + 8;
+    return [c, c, c];
+  }
+
+  args -= 16;
+
+  var rem,
+      r = Math.floor(args / 36) / 5 * 255,
+      g = Math.floor((rem = args % 36) / 6) / 5 * 255,
+      b = (rem % 6) / 5 * 255;
+
+  return [r, g, b];
+}
+
+function ansi2hsl(args) {
+  return rgb2hsl(ansi2rgb(args));
+}
+
+function ansi2hsv(args) {
+  return rgb2hsv(ansi2rgb(args));
+}
+
+function ansi2hwb(args) {
+  return rgb2hwb(ansi2rgb(args));
+}
+
+function ansi2cmyk(args) {
+  return rgb2cmyk(ansi2rgb(args));
+}
+
+function ansi2keyword(args) {
+  return rgb2keyword(ansi2rgb(args));
 }
 
 var cssKeywords = {

--- a/test/basic.js
+++ b/test/basic.js
@@ -10,12 +10,16 @@ assert.deepEqual(convert.rgb2keyword([255, 228, 196]), "bisque");
 assert.deepEqual(convert.rgb2xyz([92, 191, 84]), [25, 40, 15]);
 assert.deepEqual(convert.rgb2lab([92, 191, 84]), [70, -50, 45]);
 assert.deepEqual(convert.rgb2lch([92, 191, 84]), [70, 67, 138]);
+assert.deepEqual(convert.rgb2ansi16([92, 191, 84]), 32);
+assert.deepEqual(convert.rgb2ansi([92, 191, 84]), 114);
 
 assert.deepEqual(convert.hsl2rgb([96, 48, 59]), [140, 201, 100]);
 assert.deepEqual(convert.hsl2hsv([96, 48, 59]), [96, 50, 79]); // colorpicker says [96,50,79]
 assert.deepEqual(convert.hsl2hwb([96, 48, 59]), [96, 39, 21]); // computer round to 21, should be 22
 assert.deepEqual(convert.hsl2cmyk([96, 48, 59]), [30, 0, 50, 21]);
 assert.deepEqual(convert.hsl2keyword([240, 100, 50]), "blue");
+assert.deepEqual(convert.hsl2ansi16([240, 100, 50]), 94);
+assert.deepEqual(convert.hsl2ansi([240, 100, 50]), 21);
 
 assert.deepEqual(convert.hsv2rgb([96, 50, 78]), [139, 199, 99]);
 assert.deepEqual(convert.hsv2hsl([96, 50, 78]), [96, 47, 59]);
@@ -23,12 +27,16 @@ assert.deepEqual(convert.hsv2hsl([0,0,0]), [0,0,0]);
 assert.deepEqual(convert.hsv2hwb([96, 50, 78]), [96, 39, 22]);
 assert.deepEqual(convert.hsv2cmyk([96, 50, 78]), [30, 0, 50, 22]);
 assert.deepEqual(convert.hsv2keyword([240, 100, 100]), "blue");
+assert.deepEqual(convert.hsv2ansi16([240, 100, 100]), 94);
+assert.deepEqual(convert.hsv2ansi([240, 100, 100]), 21);
 
 assert.deepEqual(convert.cmyk2rgb([30, 0, 50, 22]), [139, 199, 99]);
 assert.deepEqual(convert.cmyk2hsl([30, 0, 50, 22]), [96, 47, 59]);
 assert.deepEqual(convert.cmyk2hsv([30, 0, 50, 22]), [96, 50, 78]);
 assert.deepEqual(convert.cmyk2hwb([30, 0, 50, 22]), [96, 39, 22]);
 assert.deepEqual(convert.cmyk2keyword([100, 100, 0, 0]), "blue");
+assert.deepEqual(convert.cmyk2ansi16([30, 0, 50, 22]), 93);
+assert.deepEqual(convert.cmyk2ansi([30, 0, 50, 22]), 150);
 
 assert.deepEqual(convert.keyword2rgb("blue"), [0, 0, 255]);
 assert.deepEqual(convert.keyword2hsl("blue"), [240, 100, 50]);
@@ -37,6 +45,8 @@ assert.deepEqual(convert.keyword2hwb("blue"), [240, 0, 0]);
 assert.deepEqual(convert.keyword2cmyk("blue"), [100, 100, 0, 0]);
 assert.deepEqual(convert.keyword2lab("blue"), [32, 79, -108]);
 assert.deepEqual(convert.keyword2xyz("blue"), [18, 7, 95]);
+assert.deepEqual(convert.keyword2ansi16("purple"), 35);
+assert.deepEqual(convert.keyword2ansi("purple"), 127);
 
 assert.deepEqual(convert.xyz2rgb([25, 40, 15]), [97, 190, 85]);
 assert.deepEqual(convert.xyz2rgb([50, 100, 100]), [0, 255, 241]);
@@ -50,6 +60,9 @@ assert.deepEqual(convert.lab2lch([69, -48, 44]), [69, 65, 137]);
 assert.deepEqual(convert.lch2lab([69, 65, 137]), [69, -48, 44]);
 assert.deepEqual(convert.lch2xyz([69, 65, 137]), [25, 39, 15]);
 assert.deepEqual(convert.lch2rgb([69, 65, 137]), [98, 188, 83]);
+
+assert.deepEqual(convert.ansi162rgb(103), [255, 255, 0]);
+assert.deepEqual(convert.ansi2rgb(175), [204, 102, 153]);
 
 // non-array arguments
 assert.deepEqual(convert.hsl2rgb(96, 48, 59), [140, 201, 100]);


### PR DESCRIPTION
So the [ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) escape codes common in modern TTY console emulators have a defined palette and scheme; I've added them here.

Over at [Chalk](/chalk), we're [looking to perform some color operations](/chalk/ansi-styles/issues/11) that have to convert from full colors to the ANSI 16/256 palettes, including allowing HSV/HSL/etc. Figured it'd be useful to put these conversion algorithms in this library and promote this since this is **impressively light but comprehensive**. :+1:

At the time of this writing, I haven't added tests; It's 1:30am and I have work in a few hours. I'll get back to this tomorrow and add them. I wanted to get this posted before I headed off, though, and see if this is something you'd want to add and to get any feedback you may have on the algorithms themselves.

It appears they work fine as it stands, though.

<img width="852" alt="screen shot 2015-07-22 at 1 59 39 am" src="https://cloud.githubusercontent.com/assets/885648/8820738/5c3fa722-3015-11e5-967b-9e585e1ff1a4.png">

At face value, they are pretty simple, but things like the greyscale palette maths required me to sit down and figure out domains and translations and stuff. Head hurts, need advil.

At any rate, we'd likely be wrapping this to use it in the event these don't land anyway, though I figured they could be of some use to users of a more general library, such as color-convert.

Thanks, and great library!

// @sindresorhus @jbnicolai